### PR TITLE
added campus functionality

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,8 @@ import {
   AllCampusesContainer,
   AllStudentsContainer,
   NewStudentContainer,
+  NewCampusContainer,
+  EditCampusContainer
   // EditStudentContainer // added edit student container
 } from './components/containers';
 // import { EditStudentContainer } from './components/containers/EditStudentContainer';
@@ -29,9 +31,11 @@ const App = () => {
         <Route exact path="/campus/:id" component={CampusContainer} />
         <Route exact path="/students" component={AllStudentsContainer} />
         <Route exact path="/newstudent" component={NewStudentContainer} />
+        <Route exact path="/newcampus" component={NewCampusContainer} />
         <Route exact path="/student/:id" component={StudentContainer} />
         {/* edit student routes */}
         <Route exact path="/student/edit/:id" component={EditStudentContainer} />
+        <Route exact path="/editcampus/:id" component={EditCampusContainer} />
       </Switch>        
     </div>
   );

--- a/src/components/containers/CampusContainer.js
+++ b/src/components/containers/CampusContainer.js
@@ -8,7 +8,10 @@ If needed, it also defines the component's "connect" function.
 import Header from './Header';
 import React, { Component } from "react";
 import { connect } from "react-redux";
-import { fetchCampusThunk } from "../../store/thunks";
+import { fetchCampusThunk,
+  deleteCampusThunk,
+  editCampusThunk
+ } from "../../store/thunks";
 
 import { CampusView } from "../views";
 
@@ -24,7 +27,9 @@ class CampusContainer extends Component {
     return (
       <div>
         <Header />
-        <CampusView campus={this.props.campus} />
+        <CampusView campus={this.props.campus}
+        deleteCampus={this.props.deleteCampus}
+        editCampus={this.props.editCampus} />
       </div>
     );
   }
@@ -43,6 +48,8 @@ const mapState = (state) => {
 const mapDispatch = (dispatch) => {
   return {
     fetchCampus: (id) => dispatch(fetchCampusThunk(id)),
+    deleteCampus: (campusId) => dispatch(deleteCampusThunk(campusId)),
+    editCampus: (campus) => dispatch(editCampusThunk(campus))
   };
 };
 

--- a/src/components/containers/EditCampusContainer.js
+++ b/src/components/containers/EditCampusContainer.js
@@ -1,0 +1,120 @@
+/*==================================================
+EditCampusContainer.js
+
+The Container component is responsible for stateful logic and data fetching, and
+passes data (if any) as props to the corresponding View component.
+If needed, it also defines the component's "connect" function.
+================================================== */
+import Header from './Header';
+import { Component } from 'react';
+import { connect } from 'react-redux';
+import { Redirect } from 'react-router-dom';
+
+import EditCampusView from '../views/EditCampusView';
+import { editCampusThunk, fetchCampusThunk } from '../../store/thunks';
+
+class EditCampusContainer extends Component {
+  // Initialize state
+  constructor(props){
+    super(props);
+    this.state = {
+      name: this.props.campus.name, 
+      imageUrl: this.props.campus.imageUrl,
+      address: this.props.campus.address,
+      description: this.props.campus.description,
+      redirect: false, 
+      redirectId: null
+    };
+  }
+
+  componentDidMount() {
+    // Get campus ID from URL (API link)
+    this.props.fetchCampus(this.props.match.params.id);
+  }
+
+  // Capture input data when it is entered
+  handleChange = event => {
+    this.setState({
+      [event.target.name]: event.target.value
+    });
+  }
+
+  // Take action after user click the submit button
+  handleSubmit = async event => {
+    event.preventDefault();  // Prevent browser reload/refresh after submit.
+
+    let campus = {
+        name: this.state.name,
+        imageUrl: this.state.imageUrl,
+        address: this.state.address,
+        description: this.state.description,
+        id: this.props.campus.id
+    };
+    
+    // Update campus in back-end database
+    await this.props.editCampus(campus);
+
+    // Update state, and trigger redirect to show the updated campus
+    this.setState({
+      name: "", 
+      imageUrl: "", 
+      address: "", 
+      description: "",
+      redirect: true, 
+      redirectId: this.props.campus.id
+    });
+  }
+
+  // Unmount when the component is being removed from the DOM:
+  componentWillUnmount() {
+      this.setState({redirect: false, redirectId: null});
+  }
+
+  // Render edit campus input form
+  render() {
+    // Redirect to updated campus's page after submit
+    if(this.state.redirect) {
+      return (<Redirect to={`/campus/${this.state.redirectId}`}/>)
+    }
+    
+    // Display the input form via the corresponding View component
+    return (
+      <div>
+        <Header />
+        <EditCampusView 
+          campus={this.props.campus.name}
+          campusName={this.state.name}
+          campusImageUrl={this.state.imageUrl}
+          campusAddress={this.state.address}
+          campusDescription={this.state.description}
+          handleChange = {this.handleChange} 
+          handleSubmit = {this.handleSubmit}      
+        />
+      </div>          
+    );
+  }
+}
+
+// The following 2 input arguments are passed to the "connect" function used by "EditCampusContainer" component to connect to Redux Store.
+// 1. The "mapState" argument specifies the data from Redux Store that the component needs.
+// The "mapState" is called when the Store State changes, and it returns a data object of "campus".
+const mapState = (state) => {
+  return {
+    campus: state.campus,  // Get the State object from Reducer "campus"
+  };
+};
+
+// The following input argument is passed to the "connect" function used by "EditCampusContainer" component to connect to Redux Store.
+// The "mapDispatch" argument is used to dispatch Action (Redux Thunk) to Redux Store.
+// The "mapDispatch" calls the specific Thunk to dispatch its action. The "dispatch" is a function of Redux Store.
+const mapDispatch = (dispatch) => {
+    return({
+      fetchCampus: (id) => dispatch(fetchCampusThunk(id)),
+      editCampus: (campus) => dispatch(editCampusThunk(campus)),
+    })
+}
+
+// Export store-connected container by default
+// EditCampusContainer uses "connect" function to connect to Redux Store and to read values from the Store 
+// (and re-read the values when the Store State updates).
+export default connect(mapState, mapDispatch)(EditCampusContainer);

--- a/src/components/containers/NewCampusContainer.js
+++ b/src/components/containers/NewCampusContainer.js
@@ -1,0 +1,99 @@
+/*==================================================
+NewCampusContainer.js
+
+The Container component is responsible for stateful logic and data fetching, and
+passes data (if any) as props to the corresponding View component.
+If needed, it also defines the component's "connect" function.
+================================================== */
+import Header from './Header';
+import { Component } from 'react';
+import { connect } from 'react-redux';
+import { Redirect } from 'react-router-dom';
+
+import NewCampusView from '../views/NewCampusView';
+import { addCampusThunk } from '../../store/thunks';
+
+class NewCampusContainer extends Component {
+  // Initialize state
+  constructor(props){
+    super(props);
+    this.state = {
+      name: "", 
+      imageUrl: "https://www.campuskit.org/admin/uploads/college-gallery/thumbs/photo-1607237138185-eedd9c632b0b1.jpg",
+      address: "",
+      description: "",
+      redirect: false, 
+      redirectId: null
+    };
+  }
+
+  // Capture input data when it is entered
+  handleChange = event => {
+    this.setState({
+      [event.target.name]: event.target.value
+    });
+  }
+
+  // Take action after user click the submit button
+  handleSubmit = async event => {
+    event.preventDefault();  // Prevent browser reload/refresh after submit.
+
+    let campus = {
+        name: this.state.name,
+        imageUrl: this.state.imageUrl,
+        address: this.state.address,
+        description: this.state.description
+    };
+    
+    // Add new campus in back-end database
+    let newCampus = await this.props.addCampus(campus);
+
+    // Update state, and trigger redirect to show the new campus
+    this.setState({
+      name: "", 
+      imageUrl: "", 
+      address: "", 
+      description: "",
+      redirect: true, 
+      redirectId: newCampus.id
+    });
+  }
+
+  // Unmount when the component is being removed from the DOM:
+  componentWillUnmount() {
+      this.setState({redirect: false, redirectId: null});
+  }
+
+  // Render new campus input form
+  render() {
+    // Redirect to new campus's page after submit
+    if(this.state.redirect) {
+      return (<Redirect to={`/campus/${this.state.redirectId}`}/>)
+    }
+
+    // Display the input form via the corresponding View component
+    return (
+      <div>
+        <Header />
+        <NewCampusView 
+          handleChange = {this.handleChange} 
+          handleSubmit = {this.handleSubmit}      
+        />
+      </div>          
+    );
+  }
+}
+
+// The following input argument is passed to the "connect" function used by "NewCampusContainer" component to connect to Redux Store.
+// The "mapDispatch" argument is used to dispatch Action (Redux Thunk) to Redux Store.
+// The "mapDispatch" calls the specific Thunk to dispatch its action. The "dispatch" is a function of Redux Store.
+const mapDispatch = (dispatch) => {
+    return({
+        addCampus: (campus) => dispatch(addCampusThunk(campus)),
+    })
+}
+
+// Export store-connected container by default
+// NewCampusContainer uses "connect" function to connect to Redux Store and to read values from the Store 
+// (and re-read the values when the Store State updates).
+export default connect(null, mapDispatch)(NewCampusContainer);

--- a/src/components/containers/index.js
+++ b/src/components/containers/index.js
@@ -13,3 +13,5 @@ export { default as CampusContainer } from "./CampusContainer";
 export { default as AllStudentsContainer } from "./AllStudentsContainer";
 export { default as StudentContainer } from "./StudentContainer";
 export { default as NewStudentContainer } from "./NewStudentContainer";
+export { default as NewCampusContainer } from "./NewCampusContainer";
+export { default as EditCampusContainer } from "./EditCampusContainer";

--- a/src/components/views/AllCampusesView.js
+++ b/src/components/views/AllCampusesView.js
@@ -10,7 +10,14 @@ import { Link } from "react-router-dom";
 const AllCampusesView = (props) => {
   // If there is no campus, display a message.
   if (!props.allCampuses.length) {
-    return <div>There are no campuses.</div>;
+    return (
+    <div>
+      <p>There are no campuses.</p>
+      <Link to={`newcampus`}>
+        <button>Add New Campus</button>
+      </Link>
+    </div>
+    );
   }
 
   // If there is at least one campus, render All Campuses view 
@@ -26,11 +33,12 @@ const AllCampusesView = (props) => {
           <h4>campus id: {campus.id}</h4>
           <p>{campus.address}</p>
           <p>{campus.description}</p>
+          <img src={campus.imageUrl} height="200" width="200" alt="college campus"/>
           <hr/>
         </div>
       ))}
       <br/>
-      <Link to={`/`}>
+      <Link to={`/newcampus`}>
         <button>Add New Campus</button>
       </Link>
       <br/><br/>

--- a/src/components/views/CampusView.js
+++ b/src/components/views/CampusView.js
@@ -8,14 +8,23 @@ import { Link } from "react-router-dom";
 
 // Take in props data to construct the component
 const CampusView = (props) => {
-  const {campus} = props;
+  const {campus, deleteCampus, editCampus} = props;
   
   // Render a single Campus view with list of its students
   return (
     <div>
       <h1>{campus.name}</h1>
+      <img src={campus.imageUrl} height="200" width="200" alt="college campus"/>
       <p>{campus.address}</p>
       <p>{campus.description}</p>
+      <Link to={`/editcampus/${campus.id}`}>
+        <button onClick={() => editCampus(campus)}>Edit Campus Information</button>
+      </Link> 
+      <br/><br/>
+      <Link to={'/campuses'}>
+        <button onClick={() => deleteCampus(campus.id)}>Delete Campus</button>
+      </Link> 
+      <h3>Total Students: {campus.students.length}</h3>
       {campus.students.map( student => {
         let name = student.firstname + " " + student.lastname;
         return (

--- a/src/components/views/EditCampusView.js
+++ b/src/components/views/EditCampusView.js
@@ -1,0 +1,86 @@
+/*==================================================
+EditCampusView.js
+
+The Views component is responsible for rendering web page with data provided by the corresponding Container component.
+It constructs a React component to display the new campus page.
+================================================== */
+import Button from '@material-ui/core/Button';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
+
+// Create styling for the input form
+const useStyles = makeStyles( () => ({
+  formContainer:{  
+    width: '500px',
+    backgroundColor: '#f0f0f5',
+    borderRadius: '5px',
+    margin: 'auto',
+  },
+  title: {
+    flexGrow: 1,
+    textAlign: 'left',
+    textDecoration: 'none'
+  }, 
+  customizeAppBar:{
+    backgroundColor: '#11153e',
+    shadows: ['none'],
+  },
+  formTitle:{
+    backgroundColor:'#c5c8d6',
+    marginBottom: '15px',
+    textAlign: 'center',
+    borderRadius: '5px 5px 0px 0px',
+    padding: '3px'
+  },
+}));
+
+const EditCampusView = (props) => {
+  const { campus, campusName, campusImageUrl, campusAddress, campusDescription, handleChange, handleSubmit } = props;
+  const classes = useStyles();
+
+  // Render an Edit Campus view with an input form
+  return (
+    <div>
+      <h1>Edit Campus</h1>
+
+      <div className={classes.root}>
+        <div className={classes.formContainer}>
+          <div className={classes.formTitle}>
+            <Typography style={{fontWeight: 'bold', fontFamily: 'Courier, sans-serif', fontSize: '20px', color: '#11153e'}}>
+              {campus}
+            </Typography>
+          </div>
+          <form style={{textAlign: 'center'}} onSubmit={(e) => handleSubmit(e)}>
+            <label style= {{color:'#11153e', fontWeight: 'bold'}}>Name: </label>
+            <input type="text" name="name" value={campusName} required="required" onChange ={(e) => handleChange(e)} />
+            <br/>
+            <br/>
+
+            <label style={{color:'#11153e', fontWeight: 'bold'}}>Image URL: </label>
+            <input type="text" name="imageUrl" value={campusImageUrl} onChange={(e) => handleChange(e)} />
+            <br/>
+            <br/>
+
+            <label style={{color:'#11153e', fontWeight: 'bold'}}>Address: </label>
+            <input type="text" name="address" value={campusAddress} required="required" onChange={(e) => handleChange(e)} />
+            <br/>
+            <br/>
+
+            <label style={{color:'#11153e', fontWeight: 'bold'}}>Description: </label>
+            <input type="text" name="description" value={campusDescription} onChange={(e) => handleChange(e)} />
+            <br/>
+            <br/>
+
+            <Button variant="contained" color="primary" type="submit">
+              Submit
+            </Button>
+            <br/>
+            <br/>
+          </form>
+          </div>
+      </div>
+    </div>    
+  )
+}
+
+export default EditCampusView;

--- a/src/components/views/NewCampusView.js
+++ b/src/components/views/NewCampusView.js
@@ -1,0 +1,90 @@
+// NewCampusView.js
+
+// The Views component is responsible for rendering web page with data provided by the corresponding Container component.
+// It constructs a React component to display the new campus page.
+// ================================================== */
+import Button from '@material-ui/core/Button';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
+
+// Create styling for the input form
+const useStyles = makeStyles( () => ({
+  formContainer:{  
+    width: '500px',
+    backgroundColor: '#f0f0f5',
+    borderRadius: '5px',
+    margin: 'auto',
+  },
+  title: {
+    flexGrow: 1,
+    textAlign: 'left',
+    textDecoration: 'none'
+  }, 
+  customizeAppBar:{
+    backgroundColor: '#11153e',
+    shadows: ['none'],
+  },
+  formTitle:{
+    backgroundColor:'#c5c8d6',
+    marginBottom: '15px',
+    textAlign: 'center',
+    borderRadius: '5px 5px 0px 0px',
+    padding: '3px'
+  },
+}));
+
+const NewCampusView = (props) => {
+  const { handleChange, handleSubmit } = props;
+  const classes = useStyles();
+
+  // Render a New Campus view with an input form
+  return (
+    <div>
+      <h1>New Campus</h1>
+
+      <div className={classes.root}>
+        <div className={classes.formContainer}>
+          <div className={classes.formTitle}>
+            <Typography style={{fontWeight: 'bold', fontFamily: 'Courier, sans-serif', fontSize: '20px', color: '#11153e'}}>
+              Add a Campus
+            </Typography>
+          </div>
+          <form style={{textAlign: 'center'}} onSubmit={(e) => handleSubmit(e)}>
+            <label style= {{color:'#11153e', fontWeight: 'bold'}}>Name: </label>
+            <input type="text" name="name" required="required" onChange ={(e) => handleChange(e)} />
+            <br/>
+            <br/>
+
+            <label style={{color:'#11153e', fontWeight: 'bold'}}>Image URL: </label>
+            <input 
+              type="text" 
+              name="imageUrl" 
+              placeholder="(optional)"
+              onChange={(e) => handleChange(e)} 
+            />
+            <br/>
+            <br/>
+
+            <label style={{color:'#11153e', fontWeight: 'bold'}}>Address: </label>
+            <input type="text" name="address" required="required" onChange={(e) => handleChange(e)} />
+            <br/>
+            <br/>
+
+            <label style={{color:'#11153e', fontWeight: 'bold'}}>Description: </label>
+            <input type="text" name="description" placeholder="Enter Description Here" onChange={(e) => handleChange(e)} />
+            <br/>
+            <br/>
+
+            <Button variant="contained" color="primary" type="submit">
+              Submit
+            </Button>
+            <br/>
+            <br/>
+          </form>
+          </div>
+      </div>
+    </div>    
+  )
+}
+
+export default NewCampusView;

--- a/src/components/views/index.js
+++ b/src/components/views/index.js
@@ -9,6 +9,7 @@ The "barrel" (module) file re-exports the exports of other modules.
 ================================================== */
 export { default as AllCampusesView } from "./AllCampusesView";
 export { default as AllStudentsView } from "./AllStudentsView";
+export { default as NewCampusView } from "./NewCampusView";
 export { default as NewStudentView } from "./NewStudentView";
 export { default as CampusView } from "./CampusView";
 export { default as StudentView } from "./StudentView";

--- a/src/store/actions/actionCreators.js
+++ b/src/store/actions/actionCreators.js
@@ -13,6 +13,28 @@ export const fetchAllCampuses = (campuses) => {
   };
 };
 
+export const addCampus = (campus) => {
+  return {
+    type: at.ADD_CAMPUS,
+    payload: campus,
+  };
+};
+
+export const deleteCampus = (campusId) => {
+  return {
+    type: at.DELETE_CAMPUS,
+    payload: campusId,
+  };
+};
+
+export const editCampus = (campus) => {
+  return {
+    type: at.EDIT_CAMPUS,
+    payload: campus,
+  };
+};
+
+
 //Single Campus
 export const fetchCampus = (campus) => {
   return {

--- a/src/store/actions/actionTypes.js
+++ b/src/store/actions/actionTypes.js
@@ -2,6 +2,9 @@
 
 //All campuses
 export const FETCH_ALL_CAMPUSES = "FETCH_ALL_CAMPUSES";
+export const ADD_CAMPUS = "ADD_CAMPUS";
+export const DELETE_CAMPUS = "DELETE_CAMPUS";
+export const EDIT_CAMPUS = "EDIT_CAMPUS";
 
 //Single campus
 export const FETCH_CAMPUS = "FETCH_CAMPUS";

--- a/src/store/reducers/campuses.js
+++ b/src/store/reducers/campuses.js
@@ -12,6 +12,16 @@ const allCampuses = (state = [], action) => {  // Empty array as default Initial
   switch (action.type) {
     case at.FETCH_ALL_CAMPUSES:
       return action.payload;
+    case at.ADD_CAMPUS:
+      return [...state, action.payload]
+    case at.DELETE_CAMPUS:
+      return state.filter(campus => campus.id!==action.payload);
+    case at.EDIT_CAMPUS:
+      return state.map(campus => { 
+        return (
+          campus.id===action.payload.id ? action.payload : campus
+        );
+      });
     default:
       // If the Reducer doesn't recognize the Action Type, returns the previous (current) State unchanged.
       return state;

--- a/src/store/thunks.js
+++ b/src/store/thunks.js
@@ -20,6 +20,47 @@ export const fetchAllCampusesThunk = () => async (dispatch) => {  // The THUNK
   }
 };
 
+// Add Campus
+// THUNK CREATOR:
+export const addCampusThunk = (campus) => async (dispatch) => {  // The THUNK
+  try {
+    // API "post" call to add "campus" object's data to database
+    let res = await axios.post(`/api/campuses`, campus);  
+    // Call Action Creator to return Action object (type + payload with new campuses data)
+    // Then dispatch the Action object to Reducer to update state 
+    dispatch(ac.addCampus(res.data));
+    return res.data;
+  } catch(err) {
+    console.error(err);
+  }
+};
+
+// Delete Campus
+// THUNK CREATOR:
+export const deleteCampusThunk = campusId => async dispatch => {  // The THUNK
+  try {
+    // API "delete" call to delete campus (based on "campusID") from database
+    await axios.delete(`/api/campuses/${campusId}`);  
+    // Delete successful so change state with dispatch
+    dispatch(ac.deleteCampus(campusId));
+  } catch(err) {
+    console.error(err);
+  }
+};
+
+// Edit Campus
+// THUNK CREATOR:
+export const editCampusThunk = campus => async dispatch => {  // The THUNK
+  try {
+    // API "put" call to update campus (based on "id" and "campus" object's data) from database
+    let updatedCampus = await axios.put(`/api/campuses/${campus.id}`, campus); 
+    // Update successful so change state with dispatch
+    dispatch(ac.editCampus(updatedCampus));
+  } catch(err) {
+    console.error(err);
+  }
+};
+
 // Single Campus
 // THUNK CREATOR:
 export const fetchCampusThunk = (id) => async (dispatch) => {  // The THUNK


### PR DESCRIPTION
with this commit we can: 
see a list of all campuses in the database
see an informative message if no campuses exist
add a new campus
delete a campus
can navigate to the Single Campus View
see details about a single campus, with all data fields, including enrolled students (if any) see an informative message if no students are enrolled at that campus  
navigate to the Single Student View and see any student's information 
add new/existing students to the campus (e.g., via link/button)  
delete students from the campus (e.g., via link/button)  
navigate to the Edit Campus View and edit the campus information  
delete the campus
can navigate to the Add Campus View, and  
enter the campus information using a form including data fields: name, address, description, and image URL.  
with a validated form displaying real-time error messages (e.g., for an invalid input)  
can navigate to the Edit Campus View
edit the campus information using a form including data fields: name, address, description, and image URL. 


